### PR TITLE
Use standard date format

### DIFF
--- a/src/dialogappointment.cpp
+++ b/src/dialogappointment.cpp
@@ -30,7 +30,7 @@ DialogAppointment::DialogAppointment(QWidget *parent, QDate *theAppointmentDate)
     this->appointmentDate=*theAppointmentDate;
     //ui->labelDateValue->setText(this->appointmentDate.toString());
 
-    QString date =locale.toString(appointmentDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(appointmentDate,QLocale::LongFormat);
     ui->labelDateValue->setText(date);
     setLabelTranslations();
 
@@ -216,7 +216,7 @@ void DialogAppointment::setLabelTranslations()
 void DialogAppointment::setLocaleDate(QLocale locale)
 {
     this->locale=locale;
-    QString date =locale.toString(appointmentDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(appointmentDate,QLocale::LongFormat);
     ui->labelDateValue->setText(date);
 }
 

--- a/src/dialogappointmentupdate.cpp
+++ b/src/dialogappointmentupdate.cpp
@@ -46,11 +46,6 @@ DialogAppointmentUpdate::DialogAppointmentUpdate(QWidget *parent, Appointment *t
 
     this->appointmentDate=QDate::fromString(theAppointment->m_date);
 
-//    QString date =locale.toString(appointmentDate,QStringLiteral("dddd dd MMMM yyyy"));
-//    ui->labelDateValue->setText(date);
-
-
-
     isAllDay=theAppointment->m_isFullDay;
 
     if (isAllDay==1)
@@ -265,7 +260,7 @@ void DialogAppointmentUpdate::setReminder1DayTranslation(QString translation)
 void DialogAppointmentUpdate::setLocaleDate(QLocale locale)
 {
     this->locale=locale;
-    QString date =locale.toString(appointmentDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(appointmentDate,QLocale::LongFormat);
     ui->labelDateValue->setText(date);
 }
 

--- a/src/dialogrepeatappointment.cpp
+++ b/src/dialogrepeatappointment.cpp
@@ -163,7 +163,7 @@ void DialogRepeatAppointment::setLabelTranslations()
 void DialogRepeatAppointment::setLocaleDate(QLocale locale)
 {
     this->locale=locale;
-    QString date =locale.toString(appointmentDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(appointmentDate,QLocale::LongFormat);
     ui->labelDate->setText(date);
 }
 

--- a/src/dialogupcomingschedule.cpp
+++ b/src/dialogupcomingschedule.cpp
@@ -37,7 +37,7 @@ DialogUpcomingSchedule::DialogUpcomingSchedule(QWidget *parent,
      QList<Appointment> schedule =QList<Appointment>();
      //QList<Appointment> dayList =QList<Appointment>();
      QDate currentDate =QDate::currentDate();
-     QString date =locale.toString(currentDate,QStringLiteral("dddd dd MMMM yyyy"));
+     QString date =locale.toString(currentDate,QLocale::LongFormat);
      ui->labelDate->setText(date);
 
      //selectedDateLabel->setText(date);
@@ -129,7 +129,7 @@ void DialogUpcomingSchedule::setLocale(QLocale locale)
 {
     this->locale=locale;
     QDate currentDate =QDate::currentDate();
-    QString date =locale.toString(currentDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(currentDate,QLocale::LongFormat);
     ui->labelDate->setText(date);
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -212,7 +212,7 @@ MainWindow::MainWindow(DbManager &dbm, QWidget *parent) :
     selectedDateLabel->setFont(font1);
 
 
-    QString date =locale.toString(selectedDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(selectedDate,QLocale::LongFormat);
     selectedDateLabel->setText(date);  
     ui->statusBar->addPermanentWidget(selectedDateLabel);
 
@@ -392,9 +392,6 @@ void MainWindow::checkForReminders()
                 {
                     //Translation needed
 
-                    //QString date =locale.toString(selectedDate,QStringLiteral("dddd dd MMMM yyyy"));
-                    //selectedDateLabel->setText(date);
-
                     QString str=a.m_title;
                     //str.append(QStringLiteral(" on "));
                     str.append(QLatin1Char(' '));
@@ -404,7 +401,7 @@ void MainWindow::checkForReminders()
                     //QDate reminderDate= QDate::fromString(a.m_date);
 
                     QString date =locale.toString(QDate::fromString(a.m_date),
-                                                  QStringLiteral("dddd dd MMMM yyyy"));
+                                                  QLocale::LongFormat);
                     str.append(date);
                     //str.append(a.m_date);
                     str.append(QLatin1Char('\n')); //new line
@@ -906,7 +903,7 @@ void MainWindow::SetPreferences()
         playAudio=preferencesDialog->isPlayAudio();
 
         //locale=getLocale(localeStr);
-        QString date =locale.toString(selectedDate,QStringLiteral("dddd dd MMMM yyyy"));
+        QString date =locale.toString(selectedDate,QLocale::LongFormat);
         selectedDateLabel->setText(date);
 
         //get new default font sizes
@@ -1015,13 +1012,13 @@ void MainWindow::gotoNextMonth()
         AddHolidaysToHolidayList(selectedYear);
         UpdateCalendar();
         selectedDate.setDate(selectedYear,selectedMonth,selectedDay);        
-        QString date =locale.toString(selectedDate,QStringLiteral("dddd dd MMMM yyyy"));
+        QString date =locale.toString(selectedDate,QLocale::LongFormat);
         selectedDateLabel->setText(date);
     }
     selectedDate.setDate(selectedYear,selectedMonth,selectedDay);
 
     ShowAppointmentsOnListView(selectedDate);    
-    QString date =locale.toString(selectedDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(selectedDate,QLocale::LongFormat);
     selectedDateLabel->setText(date);
     UpdateCalendar();
 }
@@ -1039,13 +1036,13 @@ void MainWindow::gotoPreviousMonth()
         AddHolidaysToHolidayList(selectedYear);
         UpdateCalendar();
         selectedDate.setDate(selectedYear,selectedMonth,selectedDay);        
-        QString date =locale.toString(selectedDate,QStringLiteral("dddd dd MMMM yyyy"));
+        QString date =locale.toString(selectedDate,QLocale::LongFormat);
         selectedDateLabel->setText(date);
     }
     selectedDate.setDate(selectedYear,selectedMonth,selectedDay);
     UpdateCalendar();
     ShowAppointmentsOnListView(selectedDate);   
-    QString date =locale.toString(selectedDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(selectedDate,QLocale::LongFormat);
     selectedDateLabel->setText(date);
 }
 
@@ -1058,7 +1055,7 @@ void MainWindow::gotoToday()
     AddHolidaysToHolidayList(selectedYear);
     UpdateCalendar();
     ShowAppointmentsOnListView(selectedDate);   
-    QString date =locale.toString(selectedDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(selectedDate,QLocale::LongFormat);
     selectedDateLabel->setText(date);
 }
 
@@ -1877,7 +1874,7 @@ void MainWindow::on_tableWidgetCalendar_cellClicked(int row, int column)
 
     selectedDate =QDate(selectedYear,selectedMonth,day);
 
-    QString date =locale.toString(selectedDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(selectedDate,QLocale::LongFormat);
     selectedDateLabel->setText(date);
     ShowAppointmentsOnListView(selectedDate);
 
@@ -1890,7 +1887,7 @@ void MainWindow::on_tableWidgetCalendar_cellDoubleClicked(int row, int column)
     int day =dayArray[(7 * row) + column];
     if((day<1) || (day>selectedDate.daysInMonth()) ) return;
     selectedDate =QDate(selectedYear,selectedMonth,day);    
-    QString date =locale.toString(selectedDate,QStringLiteral("dddd dd MMMM yyyy"));
+    QString date =locale.toString(selectedDate,QLocale::LongFormat);
     selectedDateLabel->setText(date);
     ShowAppointmentsOnListView(selectedDate);
     NewAppointment();


### PR DESCRIPTION
No need for a custom format when the standard long format suffices (and looks good in each user's locale).